### PR TITLE
fix: replace deprecated property in sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ class Program
                     try
                     {
                         var cr = c.Consume(cts.Token);
-                        Console.WriteLine($"Consumed message '{cr.Value}' at: '{cr.TopicPartitionOffset}'.");
+                        Console.WriteLine($"Consumed message '{cr.Message.Value}' at: '{cr.TopicPartitionOffset}'.");
                     }
                     catch (ConsumeException e)
                     {


### PR DESCRIPTION
The sample in the Readme shows accessing the Value properties from the `ConsumerResult ` object returned from the `Consume()` method. This property was deprecated, and instead, we are instructed to use the `Message.Value`.